### PR TITLE
Success remove excess

### DIFF
--- a/front-end/src/api/api.tsx
+++ b/front-end/src/api/api.tsx
@@ -4,27 +4,68 @@ import { IExercise, IWorkout } from "../data";
 import { supabase } from "../supabaseClient";
 import { v4 as uuidv4 } from "uuid";
 import { IGetFullWorkoutResponse } from "./types";
+import { ISession } from "../contexts/AuthProvider";
 
-const cookieValueAccessToken = document.cookie
+// Get Cookies from Browser
+const cookieValue_AccessToken = document.cookie
 	.split("; ")
 	.find((row) => row.startsWith("my_access_token="))
 	?.split("=")[1];
-const cookieValueRefreshToken = document.cookie
+const cookieValue_RefreshToken = document.cookie
 	.split("; ")
 	.find((row) => row.startsWith("my_refresh_token="))
 	?.split("=")[1];
-const cookieValueUserId = document.cookie
+const cookieValue_UserId = document.cookie
 	.split("; ")
 	.find((row) => row.startsWith("my_user_id="))
 	?.split("=")[1];
-// const refreshToken = document.cookie
-// 	.split("; ")
-// 	.find((row) => row.startsWith("my-refresh-token"))
-// 	?.split("=")[1];
-// const accessToken = document.cookie
-// 	.split("; ")
-// 	.find((row) => row.startsWith("my-access-token"))
-// 	?.split("=")[1];
+
+/* Good FETCH API calls - to express BE on seperate App
+	// Example POST method implementation:
+	async function postData(url = "", data = {}) {
+		// Default options are marked with *
+		const response = await fetch(url, {
+			method: "POST", // *GET, POST, PUT, DELETE, etc.
+			mode: "cors", // no-cors, *cors, same-origin
+			cache: "no-cache", // *default, no-cache, reload, force-cache, only-if-cached
+			credentials: "same-origin", // include, *same-origin, omit
+			headers: {
+				"Content-Type": "application/json",
+				// 'Content-Type': 'application/x-www-form-urlencoded',
+				},
+			redirect: "follow", // manual, *follow, error
+			referrerPolicy: "no-referrer", // no-referrer, *no-referrer-when-downgrade, origin, origin-when-cross-origin, same-origin, strict-origin, strict-origin-when-cross-origin, unsafe-url
+			body: JSON.stringify(data), // body data type must match "Content-Type" header
+		});
+		return response.json(); // parses JSON response into native JavaScript objects
+	}
+
+	postData("https://example.com/answer", { answer: 42 }).then((data) => {
+	console.log(data); // JSON data parsed by `data.json()` call
+	});
+*/
+
+export const getAllUsersWorkoutsAPI = async (session: ISession) => {
+	try {
+		const response = await fetch(`${API_ENDPOINT}/public/workouts`, {
+			headers: {
+				// headers for VERCEL deployment,
+				"Access-Token": `${session.access_token}`,
+				"Refresh-Token": `${cookieValue_RefreshToken}`,
+				"User-Id": `${cookieValue_UserId}`,
+			},
+			credentials: "include", // = will pass cookies (keeping incase i get my own domain)
+		});
+		if (response.ok) {
+			const jsonResponse = await response.json();
+			console.log("tokens???", jsonResponse);
+			return jsonResponse;
+		}
+		throw new Error("Request failed!");
+	} catch (error) {
+		console.log(error);
+	}
+};
 
 export const getWorkouts = async () => {
 	// get all of user's workouts
@@ -59,45 +100,6 @@ export const getFullWorkoutThroughSupabaseWithAuth = async (
 };
 
 //pokemonAPI
-export const getAllUsersWorkoutsAPI = async (session: any) => {
-	// get all of user's workouts
-	// const { data, error } = await supabase.from("workouts").select("name,url");
-	// if (error) {
-	// 	console.error(error);
-	// 	return;
-	// }
-	console.log("SESSSS", session);
-	console.log("COOKS", cookieValueAccessToken, cookieValueRefreshToken);
-	try {
-		const response = await fetch(`${API_ENDPOINT}/public/workouts`, {
-			method: "GET", // *GET, POST, PUT, DELETE, etc.
-			// mode: "cors", // no-cors, *cors, same-origin
-			// cache: "no-cache", // *default, no-cache, reload, force-cache, only-if-cached
-			// credentials: "same-origin", // include, *same-origin, omit
-			headers: {
-				"Access-Token": `${session.access_token}`,
-				"Refresh-Token": `${cookieValueRefreshToken}`,
-				"User-Id": `${cookieValueUserId}`,
-			},
-			// 	"Content-Type": "application/json",
-			// 	// 'Content-Type': 'application/x-www-form-urlencoded',
-			// },
-			// redirect: "follow", // manual, *follow, error
-			// referrerPolicy: "no-referrer", // no-referrer, *no-referrer-when-downgrade, origin, origin-when-cross-origin, same-origin, strict-origin, strict-origin-when-cross-origin, unsafe-url
-			// body: JSON.stringify(data), // body data type must match "Content-Type" header
-
-			credentials: "include",
-		});
-		if (response.ok) {
-			const jsonResponse = await response.json();
-			console.log("tokens???", jsonResponse);
-			return jsonResponse;
-		}
-		throw new Error("Request failed!");
-	} catch (error) {
-		console.log(error); // usually developers will redirect here
-	}
-};
 
 export const addExerciseToWorkout = async (
 	workoutId: any,

--- a/front-end/src/api/api.tsx
+++ b/front-end/src/api/api.tsx
@@ -66,6 +66,7 @@ export const getAllUsersWorkoutsAPI = async (session: any) => {
 	// 	console.error(error);
 	// 	return;
 	// }
+	console.log("SESSSS", session);
 	console.log("COOKS", cookieValueAccessToken, cookieValueRefreshToken);
 	try {
 		const response = await fetch(`${API_ENDPOINT}/public/workouts`, {

--- a/front-end/src/api/api.tsx
+++ b/front-end/src/api/api.tsx
@@ -6,19 +6,19 @@ import { v4 as uuidv4 } from "uuid";
 import { IGetFullWorkoutResponse } from "./types";
 import { ISession } from "../contexts/AuthProvider";
 
-// Get Cookies from Browser
-const cookieValue_AccessToken = document.cookie
-	.split("; ")
-	.find((row) => row.startsWith("my_access_token="))
-	?.split("=")[1];
-const cookieValue_RefreshToken = document.cookie
-	.split("; ")
-	.find((row) => row.startsWith("my_refresh_token="))
-	?.split("=")[1];
-const cookieValue_UserId = document.cookie
-	.split("; ")
-	.find((row) => row.startsWith("my_user_id="))
-	?.split("=")[1];
+// Get Cookies from Browser = redundant
+// const cookieValue_AccessToken = document.cookie
+// 	.split("; ")
+// 	.find((row) => row.startsWith("my_access_token="))
+// 	?.split("=")[1];
+// const cookieValue_RefreshToken = document.cookie
+// 	.split("; ")
+// 	.find((row) => row.startsWith("my_refresh_token="))
+// 	?.split("=")[1];
+// const cookieValue_UserId = document.cookie
+// 	.split("; ")
+// 	.find((row) => row.startsWith("my_user_id="))
+// 	?.split("=")[1];
 
 /* Good FETCH API calls - to express BE on seperate App
 	// Example POST method implementation:
@@ -46,13 +46,14 @@ const cookieValue_UserId = document.cookie
 */
 
 export const getAllUsersWorkoutsAPI = async (session: ISession) => {
+	console.log("SESSSS", session);
 	try {
 		const response = await fetch(`${API_ENDPOINT}/public/workouts`, {
 			headers: {
-				// headers for VERCEL deployment,
+				// headers for VERCEL deployment = use SESSION data, which is passed in, faster than extracting from cookies
 				"Access-Token": `${session.access_token}`,
-				"Refresh-Token": `${cookieValue_RefreshToken}`,
-				"User-Id": `${cookieValue_UserId}`,
+				"Refresh-Token": `${session.refresh_token}`,
+				"User-Id": `${session.user.id}`,
 			},
 			credentials: "include", // = will pass cookies (keeping incase i get my own domain)
 		});

--- a/front-end/src/contexts/AuthProvider.tsx
+++ b/front-end/src/contexts/AuthProvider.tsx
@@ -15,6 +15,7 @@ type IAuthContext = {
 	setUserId: (userId: string) => void;
 	user: any;
 	auth: boolean | undefined;
+	contextIsLoading: boolean;
 };
 
 export interface ISession {
@@ -35,6 +36,7 @@ export const AuthContext = React.createContext<IAuthContext>({
 	setUserId: () => {},
 	user: null,
 	auth: false,
+	contextIsLoading: true,
 });
 
 type IChildren = {
@@ -49,7 +51,7 @@ const AuthProvider: React.FC<IChildren> = ({ children }) => {
 	const [session, setSession] = useState<any | null>(null);
 	const [isLoading, setIsLoading] = useState<boolean>(true);
 	const [user, setUser] = useState<any>(null);
-	const [auth, setAuth] = useState<boolean | undefined>(undefined);
+	const [auth, setAuth] = useState<boolean>(false);
 
 	// when going to APP, get session, set if logged in
 	useEffect(() => {
@@ -138,6 +140,7 @@ const AuthProvider: React.FC<IChildren> = ({ children }) => {
 				setUserId,
 				user,
 				auth,
+				contextIsLoading: isLoading,
 			}}
 		>
 			{!isLoading && children}

--- a/front-end/src/contexts/AuthProvider.tsx
+++ b/front-end/src/contexts/AuthProvider.tsx
@@ -17,7 +17,7 @@ type IAuthContext = {
 	auth: boolean | undefined;
 };
 
-interface ISession {
+export interface ISession {
 	user: { id: string; email: string; role: string };
 	access_token: string;
 	refresh_token: string;

--- a/front-end/src/contexts/AuthProvider.tsx
+++ b/front-end/src/contexts/AuthProvider.tsx
@@ -78,22 +78,13 @@ const AuthProvider: React.FC<IChildren> = ({ children }) => {
 					setAuth(false);
 				} else if (event === "SIGNED_IN") {
 					// everytime there is a sign in event, context states will be triggered
-					console.log("did this work");
 					if (session) {
 						const maxAge = 100 * 365 * 24 * 60 * 60; // 100 years, never expires
-						document.cookie = `my_access_token=${session.access_token}; path=/; max-age=${maxAge}; SameSite=None; Secure; httpOnly=true;`;
+						document.cookie = `my_access_token=${session.access_token}; path=/; max-age=${maxAge}; SameSite=None; Secure`;
 						document.cookie = `my_refresh_token=${session.refresh_token}; path=/; max-age=${maxAge}; SameSite=None; Secure `;
-						// domain=${
-						// 	import.meta.env.VITE_COOKIE_DOMAIN
-						// }`;
 						document.cookie = `my_user_id=${session.user.id}; path=/; max-age=${maxAge}; SameSite=None; Secure`;
-						//  domain=${
-						// 	import.meta.env.VITE_COOKIE_DOMAIN
-						// }`;
 						setSession(session);
-						console.log("statechangeauth");
-						console.log("cookies:", document.cookie);
-
+						console.log("Auth Provider / AuthContext"); // log whenever auth changes and is called
 						setAuth(true);
 						setUserId(session.user.id);
 						setUsername(session.user.user_metadata.username);
@@ -101,9 +92,10 @@ const AuthProvider: React.FC<IChildren> = ({ children }) => {
 						setUser(session.user);
 					}
 				} else if (event === "SIGNED_OUT") {
-					console.log("Auth Provider, signed OUT");
+					console.log("Auth Provider:  signed OUT");
 					setAuth(false);
 					setUser(null);
+					// remove cookies, when signed out
 					const expires = new Date(0).toUTCString();
 					document.cookie = `my_access_token=; path=/; max-age=${expires}; SameSite=Lax; secure`;
 					document.cookie = `my_refresh_token=; path=/; max-age=${expires}; SameSite=Lax; secure`;

--- a/front-end/src/pages/login/LoginPage.tsx
+++ b/front-end/src/pages/login/LoginPage.tsx
@@ -7,18 +7,25 @@ import { Navigate, useNavigate } from "react-router-dom";
 
 export const LoginPage = () => {
 	// when going to AuthPage, get session, set if logged in
-	// const [isLoading, setIsLoading] = useState<boolean>(true);
-	const { auth } = useContext(AuthContext);
+	const { auth, contextIsLoading } = useContext(AuthContext);
+	const [isLoading, setIsLoading] = useState<boolean>(true);
 
-	if (auth === undefined) {
-		return <h1>LOADING</h1>;
-	} else {
-		if (auth) {
-			return <Navigate to="/workouts" />;
+	useEffect(() => {
+		if (contextIsLoading) {
+			setIsLoading(true);
+		} else {
+			setIsLoading(false);
 		}
+	}, [contextIsLoading, auth]);
+
+	if (isLoading) {
+		return <h1>LOADING</h1>;
 	}
 
-	// if not auth = false, Auth page will render
+	if (auth && !isLoading) {
+		return <Navigate to="/workouts" />;
+	}
+
 	return (
 		<div className="auth-page">
 			<p>Please Login Below</p>

--- a/front-end/src/pages/login/LoginPage.tsx
+++ b/front-end/src/pages/login/LoginPage.tsx
@@ -7,9 +7,15 @@ import { Navigate, useNavigate } from "react-router-dom";
 
 export const LoginPage = () => {
 	// when going to AuthPage, get session, set if logged in
+	// const [isLoading, setIsLoading] = useState<boolean>(true);
 	const { auth } = useContext(AuthContext);
-	if (auth) {
-		return <Navigate to="/workouts" />;
+
+	if (auth === undefined) {
+		return <h1>LOADING</h1>;
+	} else {
+		if (auth) {
+			return <Navigate to="/workouts" />;
+		}
 	}
 
 	// if not auth = false, Auth page will render

--- a/front-end/src/pages/workoutsPage/WorkoutsPage.tsx
+++ b/front-end/src/pages/workoutsPage/WorkoutsPage.tsx
@@ -14,23 +14,13 @@ export const WorkoutsPage: React.FC<{}> = () => {
 	useEffect(() => {
 		// get all of user's workouts to render list
 		const getAllUsersWorkouts = async () => {
-			// const { data, error } = await supabase
-			// 	.from("workouts")
-			// 	.select("id, name, url, last_performed");
-			///
-			const data = await getAllUsersWorkoutsAPI(session);
-			// console.log("pokemons", pokemons);
-			// if (error) {	move error handling to api
-			// 	console.error(error);
-			// 	setIsLoading(false);
-			// 	return;
-			// }
-			// console.log("session", session);
-			if (data) {
-				setWorkouts(data);
-				setIsLoading(false);
+			if (session) {
+				const data = await getAllUsersWorkoutsAPI(session);
+				if (data) {
+					setWorkouts(data);
+					setIsLoading(false);
+				}
 			}
-			// return data;
 		};
 		getAllUsersWorkouts();
 	}, []);


### PR DESCRIPTION
1. fd90745 = cookies do not need DOMAIN prop right now, since within vercel.app, cookies cannot be sent, so using headers, but cookies are still set for use in localhost, or for when it is deployed to own domain 
2. organized AuthContext = added a contextIsLoading, 
- Login Page, uses is loading to render or redirect or loading sign
- will use in most component when waiting for a Context var. 
3. started to organize API on FE page, with proper documentation. 

- two things are being done, refresh token, access token, and user id need to be passed to express BE server, but COOKIES don't work on vercel, so using HEADERS for that, but credentials are "included" so cookie use can also be implemented