### PR TITLE
Add amiibo page

### DIFF
--- a/front-end/amiiboBuddy/components/AmiiboBuddyHomePage.tsx
+++ b/front-end/amiiboBuddy/components/AmiiboBuddyHomePage.tsx
@@ -18,7 +18,7 @@ export const AmiiboBuddyHomePage: React.FC<{}> = () => {
 
 	useEffect(() => {
 		if (!isLoading) {
-			console.log("amiiiii", amiibos);
+			// console.log("amiiiii", amiibos);
 		}
 	}, [isLoading]);
 
@@ -40,7 +40,7 @@ export const AmiiboBuddyHomePage: React.FC<{}> = () => {
 			.order("amiibo_series");
 		if (data) {
 			setAmiibos(data);
-			console.log("Amiibo Data", data);
+			// console.log("Amiibo Data", data);
 			setIsLoading(false);
 		} else {
 			console.error("ERROR", error);
@@ -54,7 +54,9 @@ export const AmiiboBuddyHomePage: React.FC<{}> = () => {
 			<h2 className="page-heading">Amiibo Buddy</h2>
 			<div className="amiibo-grid">
 				{!isLoading &&
-					amiibos.map((amiibo) => <AmiiboCard amiibo={amiibo} />)}
+					amiibos.map((amiibo, index) => (
+						<AmiiboCard amiibo={amiibo} key={index} />
+					))}
 			</div>
 		</div>
 	);

--- a/front-end/amiiboBuddy/components/AmiiboInventoryForm.tsx
+++ b/front-end/amiiboBuddy/components/AmiiboInventoryForm.tsx
@@ -382,19 +382,21 @@ export const AmiiboInventoryForm: React.FC<{}> = () => {
 						label="Rate"
 						style={{ color: "white", textAlign: "center" }}
 					>
-						Awful
-						<Rate
-							count={5}
-							style={{
-								backgroundColor: "grey",
-								padding: "0px 10px",
-								borderRadius: "10px",
-								margin: "0px 10px",
-							}}
-							allowHalf
-							onChange={(value) => handleRateChange(value)}
-						/>
-						Perfect
+						<>
+							Awful
+							<Rate
+								count={5}
+								style={{
+									backgroundColor: "grey",
+									padding: "0px 10px",
+									borderRadius: "10px",
+									margin: "0px 10px",
+								}}
+								allowHalf
+								onChange={(value) => handleRateChange(value)}
+							/>
+							Perfect
+						</>
 					</Form.Item>
 
 					<FormItem name="condition" label="Condition">

--- a/front-end/src/AuthRoute.tsx
+++ b/front-end/src/AuthRoute.tsx
@@ -1,20 +1,28 @@
+import React from "react";
+
 import { useContext, useEffect, useState } from "react";
-import { Navigate, Outlet } from "react-router-dom";
+import { Navigate, Outlet, useLocation } from "react-router-dom";
 import { AuthContext } from "./contexts/AuthProvider";
 import { SpiningLoadingIcon } from "./components/loading/LoadingIcon";
 
 const AuthRoute = () => {
 	const { auth, contextIsLoading } = useContext(AuthContext);
 	const [isLoading, setIsLoading] = useState<boolean>(true);
+	const location = useLocation();
 
 	useEffect(() => {
 		if (!contextIsLoading && auth !== undefined) {
+			// console.log("AuthPAge, ", location);
 			setIsLoading(false);
 		}
 	}, [auth]);
 
 	if (!isLoading && auth !== undefined) {
-		return auth ? <Outlet /> : <Navigate to="/login" />;
+		return auth ? (
+			<Outlet />
+		) : (
+			<Navigate to="/login" state={{ from: location }} />
+		);
 	} else {
 		return <SpiningLoadingIcon />;
 	}

--- a/front-end/src/AuthRoute.tsx
+++ b/front-end/src/AuthRoute.tsx
@@ -23,6 +23,26 @@ const AuthRoute = () => {
 			setPreviousDomain(subDomain);
 			setIsLoading(false);
 		}
+		if (!contextIsLoading && auth === false) {
+			console.log("AuthRoute: location of URL, ", location);
+			// extract just DOMAIN
+			const splitPathName = location.pathname.split("/");
+			console.log("split URL ", splitPathName);
+			const subDomain =
+				splitPathName[1] in domains ? splitPathName[1] : "buddySystem";
+			setPreviousDomain(subDomain);
+			setIsLoading(false);
+		}
+		if (!contextIsLoading && auth === true) {
+			console.log("AuthRoute: location of URL, TRUE", location);
+			// extract just DOMAIN
+			const splitPathName = location.pathname.split("/");
+			console.log("split URL ", splitPathName);
+			const subDomain =
+				splitPathName[1] in domains ? splitPathName[1] : "buddySystem";
+			setPreviousDomain(subDomain);
+			setIsLoading(false);
+		}
 	}, [auth]);
 
 	useEffect(() => {

--- a/front-end/src/AuthRoute.tsx
+++ b/front-end/src/AuthRoute.tsx
@@ -21,7 +21,10 @@ const AuthRoute = () => {
 		return auth ? (
 			<Outlet />
 		) : (
-			<Navigate to="/login" state={{ from: location }} />
+			<Navigate
+				to="/login"
+				state={{ initialUrl: location, fromLogin: false }}
+			/>
 		);
 	} else {
 		return <SpiningLoadingIcon />;

--- a/front-end/src/AuthRoute.tsx
+++ b/front-end/src/AuthRoute.tsx
@@ -4,18 +4,30 @@ import { useContext, useEffect, useState } from "react";
 import { Navigate, Outlet, useLocation } from "react-router-dom";
 import { AuthContext } from "./contexts/AuthProvider";
 import { SpiningLoadingIcon } from "./components/loading/LoadingIcon";
+import { domains } from "./utils/utils";
 
 const AuthRoute = () => {
 	const { auth, contextIsLoading } = useContext(AuthContext);
 	const [isLoading, setIsLoading] = useState<boolean>(true);
 	const location = useLocation();
+	const [previousDomain, setPreviousDomain] = useState<string>();
 
 	useEffect(() => {
 		if (!contextIsLoading && auth !== undefined) {
-			// console.log("AuthPAge, ", location);
+			console.log("AuthRoute: location of URL, ", location);
+			// extract just DOMAIN
+			const splitPathName = location.pathname.split("/");
+			console.log("split URL ", splitPathName);
+			const subDomain =
+				splitPathName[1] in domains ? splitPathName[1] : "buddySystem";
+			setPreviousDomain(subDomain);
 			setIsLoading(false);
 		}
 	}, [auth]);
+
+	useEffect(() => {
+		console.log("AuthRoute: previousDomain: ", previousDomain);
+	}, [previousDomain]);
 
 	if (!isLoading && auth !== undefined) {
 		return auth ? (
@@ -23,7 +35,10 @@ const AuthRoute = () => {
 		) : (
 			<Navigate
 				to="/login"
-				state={{ initialUrl: location, fromLogin: false }}
+				state={{
+					initialUrl: location.pathname,
+					previousDomain: previousDomain,
+				}}
 			/>
 		);
 	} else {

--- a/front-end/src/api/types.ts
+++ b/front-end/src/api/types.ts
@@ -89,3 +89,9 @@ export type TDomains = {
 		class: string;
 	};
 };
+
+export type TDomain = {
+	name: string;
+	path: string;
+	class: string;
+};

--- a/front-end/src/components/header/Header.tsx
+++ b/front-end/src/components/header/Header.tsx
@@ -5,7 +5,7 @@ import { Link } from "react-router-dom";
 import LogInButton from "./LogInButton";
 import { useLocation } from "react-router-dom";
 import { domainFromUrl } from "../../utils/utils";
-import { TDomains } from "../../api/types";
+import { TDomain, TDomains } from "../../api/types";
 import { domains } from "../../utils/utils";
 
 export const Header: React.FC<{}> = () => {
@@ -16,27 +16,28 @@ export const Header: React.FC<{}> = () => {
 	const location = useLocation();
 	const splitUrl = location.pathname.split("/");
 	const domain = splitUrl[1] in domains ? splitUrl[1] : "buddySystem";
+	const [domainObj, setDomainObj] = useState<TDomain>(); // wait for username to be fetched before rendering.
+
+	useEffect(() => {
+		setDomainObj(domains[domain]);
+	}, []);
 	// update everytime username changes; if username exists, put it on display, if not, default
 	useEffect(() => {
 		if (!contextIsLoading) {
 			if (username) {
 				setDisplayUsername(username);
+				// console.log("LOCATION", domain);
 				setIsLoading(false);
-				console.log("LOCATION", domain);
 			}
 		}
-	}, [auth]);
-
-	useEffect(() => {
-		if (domain) console.log("domain", domain);
-	}, [domain]);
+	}, [auth, contextIsLoading, domainObj, username]);
 
 	return (
 		<div className={`header ${domains[domain].class}-header`} key={domain}>
 			<div className="content white-font">
-				{!isLoading ? (
-					auth ? (
-						domain && (
+				{!isLoading &&
+					(auth ? (
+						domainObj && (
 							<>
 								<Link
 									to={`${domains[domain].path}`}
@@ -60,20 +61,74 @@ export const Header: React.FC<{}> = () => {
 						)
 					) : (
 						<>
-							<Link to="/">
+							{/* <Link to="/">
 								<h1>{domain}</h1>
 							</Link>
 							{!(location.pathname === "/login") && ( // login button appears if not authorized, and not on /login page.
 								<Link to="/login">
 									<LogInButton />
 								</Link>
-							)}
+							)} */}
 						</>
-					)
-				) : (
-					<Link to="/">{/* <h1>Workout Buddy</h1> */}</Link>
-				)}
+					))}
 			</div>
 		</div>
 	);
 };
+
+/*
+
+1. once loading is false 
+	2. render DOMAIN as header 
+	3. set domain as helmet too 
+		2. if auth, render log out <button></button>
+		5. if NOT AUTH, render log in button, redirect to domain homepage. 
+
+		*/
+
+// return (
+// 	<div className={`header ${domains[domain].class}-header`} key={domain}>
+// 		<div className="content white-font">
+// 			{!isLoading ? (
+// 				auth ? (
+// 					domainObj && (
+// 						<>
+// 							<Link
+// 								to={`${domains[domain].path}`}
+// 								key={domain}
+// 							>
+// 								{domain && (
+// 									<h1 key={domain}>
+// 										{domains[domain].name}
+// 									</h1>
+// 								)}
+// 							</Link>
+// 							<div className="account">
+// 								<Link to="/createUsername">
+// 									{!username
+// 										? "Create Username"
+// 										: displayUsername}
+// 								</Link>
+// 								<LogoutButton />
+// 							</div>
+// 						</>
+// 					)
+// 				) : (
+// 					<>
+// 						<Link to="/">
+// 							<h1>{domain}</h1>
+// 						</Link>
+// 						{!(location.pathname === "/login") && ( // login button appears if not authorized, and not on /login page.
+// 							<Link to="/login">
+// 								<LogInButton />
+// 							</Link>
+// 						)}
+// 					</>
+// 				)
+// 			) : (
+// 				<Link to="/">{/* <h1>Workout Buddy</h1> */}</Link>
+// 			)}
+// 		</div>
+// 	</div>
+// );
+// };

--- a/front-end/src/components/header/Header.tsx
+++ b/front-end/src/components/header/Header.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useState } from "react";
 import LogoutButton from "./LogOutButton";
 import { AuthContext } from "../../contexts/AuthProvider";
-import { Link } from "react-router-dom";
+import { Link, Location } from "react-router-dom";
 import LogInButton from "./LogInButton";
 import { useLocation } from "react-router-dom";
 import { domainFromUrl } from "../../utils/utils";
@@ -20,34 +20,104 @@ export const Header: React.FC<{}> = () => {
 	// const [subdomain, setSubdomain] = useState<string>(domain);
 	const [domainObj, setDomainObj] = useState<TDomain>(); // wait for username to be fetched before rendering.
 	const [fromLoginHeaderClass, setFromLoginHeaderClass] = useState<string>();
-
+	const [previousDomain, setPreviousDomain] = useState<string | undefined>();
+	const [currentDomain, setCurrentDomain] = useState<string>();
+	const [headerTransition, setHeaderTransition] = useState<string>("/");
+	// SET HEADING AFFECT FROM PREVIOUS URL = TAKE THE DOMAIN FROM IT, and you can compare
+	// "poreviousDomain " + "-" + "current Domain" + " +  fade"
 	useEffect(() => {
 		setDomainObj(domains[domain]);
 	}, []);
 
-	const getDomainFromPathName = (pathname: string) => {
-		const splitPathName = pathname.split("/");
+	// const getDomainFromPathName = (location: Location) => {
+	// 	if (location.pathname.length > 0) {
+	// 		const splitPathName = location.pathname.split("/");
+	// 		const subDomain =
+	// 			splitPathName[1] in domains ? splitPathName[1] : "buddySystem";
+	// 		return subDomain;
+	// 	}
+	// };
+
+	useEffect(() => {
+		console.log("Location header = ", location);
+		const splitPathName = location.pathname.split("/");
+		console.log("Location header = ", splitPathName);
 		const subDomain =
 			splitPathName[1] in domains ? splitPathName[1] : "buddySystem";
-		return subDomain;
-	};
-	useEffect(() => {
-		if (location.state) {
-			if (location.state.fromLogin) {
-				console.log("from login?", location.state);
-				setFromLoginHeaderClass("from-login");
-				console.log("afterAlter?", location.state);
-			}
+		setCurrentDomain(subDomain);
+		console.log("currentDomain", subDomain);
+		if (location.state?.previousDomain) {
+			const previousDomainnn = location.state.previousDomain;
+			console.log("previousDomainnn", previousDomainnn);
+			setPreviousDomain(previousDomainnn);
+		} else {
+			console.log("previousDomain", previousDomain);
 		}
+	}, [location, auth]);
 
-		// if (domainObj) {
-		// 	if (splitUrl[1] !== domain) {
-		// 		console.log("NEW SUBDOMAIN", splitUrl[1], domain, location);
-		// 	}
+	// useEffect(() => {
+	// 	console.log("location by header", location);
+	// 	if (contextIsLoading && location) {
+	// 		if (location.state?.previousUrl) {
+	// 			console.log(location.state.previousUrl);
+	// 			const getPreviousDomain = getDomainFromPathName(
+	// 				location.state.previousUrl
+	// 			);
+	// 			setPreviousDomain(getPreviousDomain);
+	// 			console.log("getPreviousDomain", getPreviousDomain);
+	// 		}
+	// 		console.log("PREVIOUS DOMAIN :", previousDomain);
+	// 		setCurrentDomain(domain);
+	// 		console.log("DOMAIN          :", domain);
+	// 	}
+	// }, []);
+
+	// useEffect(() => {
+	// 	// if (location.state) {
+	// 	// 	if (location.state.fromLogin) {
+	// 	// 		console.log("from login?", location.state);
+	// 	// 		setFromLoginHeaderClass("from-login");
+	// 	// 		console.log("afterAlter?", location.state);
+	// 	// 	}
+	// 	// 	if (location.state.previousUrl) {
+	// 	// 		console.log("from login?", location.state);
+	// 	// 		setFromLoginHeaderClass("from-login");
+	// 	// 		console.log("afterAlter?", location.state);
+	// 	// 	}
+	// 	// }
+	// 	setCurrentDomain(domain);
+	// 	// if (domainObj) {
+	// 	// 	if (splitUrl[1] !== domain) {
+	// 	// 		console.log("NEW SUBDOMAIN", splitUrl[1], domain, location);
+	// 	// 	}
+	// 	// }
+
+	// 	// console.log("test", `fade-${previousDomain}-to-${domain}`);
+
+	// 	setDomainObj(domains[domain]);
+	// }, []);
+
+	useEffect(() => {
+		// console.log("current location", location);
+		// console.log("PREVIOUS Domain:", previousDomain);
+		// console.log("CURRENT domain :", domain);
+		// if (!previousDomain || previousDomain === currentDomain) {
+		// 	setHeaderTransition(`${domain}`);
+		// 	console.log("TEST           :", `${domain}`);
+		// } else {
+		// 	setHeaderTransition(`${previousDomain}-to-${domain}`);
+		// 	console.log("TEST", `${previousDomain}-to-${domain}`);
 		// }
-		console.log("change in domain", location, domain);
-		setDomainObj(domains[domain]);
-	}, [location]);
+		if (previousDomain === currentDomain || !previousDomain) {
+			setHeaderTransition(`${currentDomain}-header`);
+		} else {
+			setHeaderTransition(`${previousDomain}-to-${currentDomain}-header`);
+		}
+	}, [currentDomain]);
+
+	useEffect(() => {
+		console.log("HEADER TRANSITION", headerTransition);
+	}, [currentDomain]);
 
 	// update everytime username changes; if username exists, put it on display, if not, default
 	useEffect(() => {
@@ -66,12 +136,13 @@ export const Header: React.FC<{}> = () => {
 			}
 		}
 	}, [auth, contextIsLoading, domainObj, username]);
+	// ${previousDomain}-previous-domain-header
+	// ${domains[domain].class}-header
+	// 		${headerTransition}
+	// 		  ${fromLoginHeaderClass}
 
 	return (
-		<div
-			className={`header ${domains[domain].class}-header ${fromLoginHeaderClass}`}
-			key={domain}
-		>
+		<div className={`header ${headerTransition}`} key={domain}>
 			<div className="content white-font">
 				{!isLoading &&
 					(auth ? (

--- a/front-end/src/components/header/Header.tsx
+++ b/front-end/src/components/header/Header.tsx
@@ -7,6 +7,7 @@ import { useLocation } from "react-router-dom";
 import { domainFromUrl } from "../../utils/utils";
 import { TDomain, TDomains } from "../../api/types";
 import { domains } from "../../utils/utils";
+import { SpiningLoadingIcon } from "../loading/LoadingIcon";
 
 export const Header: React.FC<{}> = () => {
 	const { username, isLoggedIn, auth, contextIsLoading } =
@@ -26,10 +27,13 @@ export const Header: React.FC<{}> = () => {
 		if (!contextIsLoading) {
 			if (username) {
 				setDisplayUsername(username);
-				// console.log("LOCATION", domain);
 				setIsLoading(false);
 			}
 		}
+		if (domain === "buddySystem" && auth === false && !username) {
+			setIsLoading(false);
+		}
+		console.log("LOCATION", domainObj);
 	}, [auth, contextIsLoading, domainObj, username]);
 
 	return (
@@ -61,14 +65,14 @@ export const Header: React.FC<{}> = () => {
 						)
 					) : (
 						<>
-							{/* <Link to="/">
-								<h1>{domain}</h1>
+							<Link to="/">
+								<h1>{domainObj?.name}</h1>
 							</Link>
 							{!(location.pathname === "/login") && ( // login button appears if not authorized, and not on /login page.
 								<Link to="/login">
 									<LogInButton />
 								</Link>
-							)} */}
+							)}
 						</>
 					))}
 			</div>

--- a/front-end/src/components/header/Header.tsx
+++ b/front-end/src/components/header/Header.tsx
@@ -17,18 +17,29 @@ export const Header: React.FC<{}> = () => {
 	const location = useLocation();
 	const splitUrl = location.pathname.split("/");
 	const domain = splitUrl[1] in domains ? splitUrl[1] : "buddySystem";
-	const [subdomain, setSubdomain] = useState<string>(domain);
+	// const [subdomain, setSubdomain] = useState<string>(domain);
 	const [domainObj, setDomainObj] = useState<TDomain>(); // wait for username to be fetched before rendering.
-	const [fromLoginHeaderClass, setFromLoginHeaderClass] = useState<boolean>();
+	const [fromLoginHeaderClass, setFromLoginHeaderClass] = useState<string>();
 
 	useEffect(() => {
 		setDomainObj(domains[domain]);
 	}, []);
 
+	const getDomainFromPathName = (pathname: string) => {
+		const splitPathName = pathname.split("/");
+		const subDomain =
+			splitPathName[1] in domains ? splitPathName[1] : "buddySystem";
+		return subDomain;
+	};
 	useEffect(() => {
-		if (!auth && domain === "/login") {
-			console.log("Just logged out from ", location.state.previousDomain);
+		if (location.state) {
+			if (location.state.fromLogin) {
+				console.log("from login?", location.state);
+				setFromLoginHeaderClass("from-login");
+				console.log("afterAlter?", location.state);
+			}
 		}
+
 		// if (domainObj) {
 		// 	if (splitUrl[1] !== domain) {
 		// 		console.log("NEW SUBDOMAIN", splitUrl[1], domain, location);
@@ -57,7 +68,10 @@ export const Header: React.FC<{}> = () => {
 	}, [auth, contextIsLoading, domainObj, username]);
 
 	return (
-		<div className={`header ${domains[domain].class}-header`} key={domain}>
+		<div
+			className={`header ${domains[domain].class}-header ${fromLoginHeaderClass}`}
+			key={domain}
+		>
 			<div className="content white-font">
 				{!isLoading &&
 					(auth ? (

--- a/front-end/src/components/header/Header.tsx
+++ b/front-end/src/components/header/Header.tsx
@@ -17,11 +17,27 @@ export const Header: React.FC<{}> = () => {
 	const location = useLocation();
 	const splitUrl = location.pathname.split("/");
 	const domain = splitUrl[1] in domains ? splitUrl[1] : "buddySystem";
+	const [subdomain, setSubdomain] = useState<string>(domain);
 	const [domainObj, setDomainObj] = useState<TDomain>(); // wait for username to be fetched before rendering.
+	const [fromLoginHeaderClass, setFromLoginHeaderClass] = useState<boolean>();
 
 	useEffect(() => {
 		setDomainObj(domains[domain]);
 	}, []);
+
+	useEffect(() => {
+		if (!auth && domain === "/login") {
+			console.log("Just logged out from ", location.state.previousDomain);
+		}
+		// if (domainObj) {
+		// 	if (splitUrl[1] !== domain) {
+		// 		console.log("NEW SUBDOMAIN", splitUrl[1], domain, location);
+		// 	}
+		// }
+		console.log("change in domain", location, domain);
+		setDomainObj(domains[domain]);
+	}, [location]);
+
 	// update everytime username changes; if username exists, put it on display, if not, default
 	useEffect(() => {
 		if (!contextIsLoading) {
@@ -29,11 +45,15 @@ export const Header: React.FC<{}> = () => {
 				setDisplayUsername(username);
 				setIsLoading(false);
 			}
+			if (domain === "buddySystem" && !username) {
+				setIsLoading(false);
+			}
 		}
-		if (domain === "buddySystem" && auth === false && !username) {
-			setIsLoading(false);
+		if (domainObj && auth === false) {
+			if (domain === "buddySystem") {
+				setIsLoading(false);
+			}
 		}
-		console.log("LOCATION", domainObj);
 	}, [auth, contextIsLoading, domainObj, username]);
 
 	return (

--- a/front-end/src/components/header/Header.tsx
+++ b/front-end/src/components/header/Header.tsx
@@ -113,7 +113,7 @@ export const Header: React.FC<{}> = () => {
 		} else {
 			setHeaderTransition(`${previousDomain}-to-${currentDomain}-header`);
 		}
-	}, [currentDomain]);
+	}, [currentDomain, previousDomain]);
 
 	useEffect(() => {
 		console.log("HEADER TRANSITION", headerTransition);

--- a/front-end/src/components/header/LogOutButton.tsx
+++ b/front-end/src/components/header/LogOutButton.tsx
@@ -2,25 +2,39 @@ import React, { useContext, useState } from "react";
 import { Button } from "antd";
 import { supabase } from "../../supabaseClient";
 import { AuthContext } from "../../contexts/AuthProvider";
-import { useNavigate } from "react-router-dom";
+import { Navigate, useLocation, useNavigate } from "react-router-dom";
 // import { getSignOut } from "../../api/api";
 const LogoutButton: React.FC<{}> = () => {
 	const { setUsername, setIsLoggedIn, setUserId, user } =
 		useContext(AuthContext);
 	const [isLoading, setIsLoading] = useState<boolean>(false);
-
+	const location = useLocation();
 	const navigate = useNavigate();
 
 	const handleSignout = async () => {
 		try {
 			setIsLoading(true);
+			const previousDomain = location.pathname;
+			console.log("logoutbutton prevdomain", previousDomain);
 			// const res = await getSignOut();
-			console.log("what is the res ");
+			// console.log("what is the res ");
 			const { error } = await supabase.auth.signOut();
 			if (error) {
 				throw error;
 			} else {
+				// navigate("/login", {
+				// 	state: { previousDomain: previousDomain },
+				// });
 				setIsLoggedIn(false);
+				return (
+					<Navigate
+						to={"/login"}
+						state={{
+							previousUrl: location.pathname,
+							fromLogout: true,
+						}}
+					/>
+				);
 			}
 			// const expires = new Date(0).toUTCString();
 			// document.cookie = `my_access_token=; path=/; max-age=${expires}; SameSite=Lax; secure`;

--- a/front-end/src/contexts/AuthProvider.tsx
+++ b/front-end/src/contexts/AuthProvider.tsx
@@ -74,6 +74,8 @@ const AuthProvider: React.FC<IChildren> = ({ children }) => {
 					setAuth(false);
 				}
 				// setIsLoading(false); remove because next useEffect should also alway run atleast
+				setIsLoading(false);
+
 				return;
 			});
 		};

--- a/front-end/src/pages/login/LoginPage.tsx
+++ b/front-end/src/pages/login/LoginPage.tsx
@@ -6,6 +6,7 @@ import { AuthContext } from "../../contexts/AuthProvider";
 import { Navigate, useLocation } from "react-router-dom";
 import { SpiningLoadingIcon } from "../../components/loading/LoadingIcon";
 import "../../styles/index.css";
+import { domains } from "../../utils/utils";
 
 type TProps = {
 	from: string;
@@ -15,24 +16,55 @@ export const LoginPage = () => {
 	// when going to AuthPage, get session, set if logged in
 	const { auth, contextIsLoading } = useContext(AuthContext);
 	const [isLoading, setIsLoading] = useState<boolean>(true);
-	const location = useLocation();
+	const [previousDomain, setPreviousDomain] = useState<string>();
 
+	const location = useLocation();
 	// if entered Auth Url => send back to that URL once Auth
 	// if not from Auth URL (homepage) => then no state will be given
 	const redirectLocation = location.state ? location.state.initialUrl : "/";
+	// if there is no state = straight to login page = redirect to "/"']
+
+	// useEffect(() => {
+	// 	console.log("location login ", location);
+	// }, []);
 
 	useEffect(() => {
 		if (!contextIsLoading && auth !== undefined) {
+			// if (redirectLocation !== "/") {
+			// 	if (redirectLocation?.pathename) {
+			// 		// const splitPathName = redirectLocation.pathname.split("/");
+			// const subDomain =
+			// 	splitPathName[1] in domains
+			// 		? splitPathName[1]
+			// 		: "buddySystem";
+			// setPreviousDomain(subDomain);
+			// console.log(
+			// 	"SET Previous DOMAIN to login PAGE ",
+			// 	subDomain
+			// );
+			// }
+			// console.log("redirectLocation", redirectLocation);
+			// console.log("location", location.state);
+			// previous domain = undefined if no prev exist   /  /
+			// }
+			if (location.state?.pathename) {
+				setPreviousDomain(location.state.pathename);
+				console.log("prev domain", location.state.pathename);
+			} else {
+				setPreviousDomain(undefined);
+			}
+
 			setIsLoading(false);
 		}
-		console.log("redirectLocation", redirectLocation);
 	}, [auth]);
+
+	// if location = null = no location.state = went STRAIGHT to login page
 
 	return !isLoading ? (
 		auth ? (
 			<Navigate
 				to={redirectLocation}
-				state={{ ...location.state, fromLogin: true }}
+				state={{ previousUrl: previousDomain }}
 			/>
 		) : (
 			<div className="auth-page">

--- a/front-end/src/pages/login/LoginPage.tsx
+++ b/front-end/src/pages/login/LoginPage.tsx
@@ -15,14 +15,11 @@ export const LoginPage = () => {
 	// when going to AuthPage, get session, set if logged in
 	const { auth, contextIsLoading } = useContext(AuthContext);
 	const [isLoading, setIsLoading] = useState<boolean>(true);
-	console.log("initial Login page");
 	const location = useLocation();
 
 	// if entered Auth Url => send back to that URL once Auth
 	// if not from Auth URL (homepage) => then no state will be given
-	const redirectLocation = location.state
-		? location.state.from.pathname
-		: "/";
+	const redirectLocation = location.state ? location.state.initialUrl : "/";
 
 	useEffect(() => {
 		if (!contextIsLoading && auth !== undefined) {
@@ -33,7 +30,10 @@ export const LoginPage = () => {
 
 	return !isLoading ? (
 		auth ? (
-			<Navigate to={redirectLocation} state={{ fromLogin: true }} />
+			<Navigate
+				to={redirectLocation}
+				state={{ ...location.state, fromLogin: true }}
+			/>
 		) : (
 			<div className="auth-page">
 				<p>Please Login Below</p>

--- a/front-end/src/pages/login/LoginPage.tsx
+++ b/front-end/src/pages/login/LoginPage.tsx
@@ -3,25 +3,37 @@ import { supabase } from "../../supabaseClient";
 import { ThemeSupa } from "@supabase/auth-ui-shared";
 import { useContext, useEffect, useState } from "react";
 import { AuthContext } from "../../contexts/AuthProvider";
-import { Navigate } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 import { SpiningLoadingIcon } from "../../components/loading/LoadingIcon";
 import "../../styles/index.css";
+
+type TProps = {
+	from: string;
+};
 
 export const LoginPage = () => {
 	// when going to AuthPage, get session, set if logged in
 	const { auth, contextIsLoading } = useContext(AuthContext);
 	const [isLoading, setIsLoading] = useState<boolean>(true);
 	console.log("initial Login page");
+	const location = useLocation();
+
+	// if entered Auth Url => send back to that URL once Auth
+	// if not from Auth URL (homepage) => then no state will be given
+	const redirectLocation = location.state
+		? location.state.from.pathname
+		: "/";
 
 	useEffect(() => {
 		if (!contextIsLoading && auth !== undefined) {
 			setIsLoading(false);
 		}
+		console.log("redirectLocation", redirectLocation);
 	}, [auth]);
 
 	return !isLoading ? (
 		auth ? (
-			<Navigate to="/workouts" />
+			<Navigate to={redirectLocation} state={{ fromLogin: true }} />
 		) : (
 			<div className="auth-page">
 				<p>Please Login Below</p>

--- a/front-end/src/pages/login/LoginPage.tsx
+++ b/front-end/src/pages/login/LoginPage.tsx
@@ -3,7 +3,7 @@ import { supabase } from "../../supabaseClient";
 import { ThemeSupa } from "@supabase/auth-ui-shared";
 import { useContext, useEffect, useState } from "react";
 import { AuthContext } from "../../contexts/AuthProvider";
-import { Navigate, useLocation } from "react-router-dom";
+import { Navigate, useLocation, useNavigate } from "react-router-dom";
 import { SpiningLoadingIcon } from "../../components/loading/LoadingIcon";
 import "../../styles/index.css";
 import { domains } from "../../utils/utils";
@@ -17,7 +17,7 @@ export const LoginPage = () => {
 	const { auth, contextIsLoading } = useContext(AuthContext);
 	const [isLoading, setIsLoading] = useState<boolean>(true);
 	const [previousDomain, setPreviousDomain] = useState<string>();
-
+	const navigate = useNavigate();
 	const location = useLocation();
 	// if entered Auth Url => send back to that URL once Auth
 	// if not from Auth URL (homepage) => then no state will be given
@@ -30,26 +30,16 @@ export const LoginPage = () => {
 
 	useEffect(() => {
 		if (!contextIsLoading && auth !== undefined) {
-			// if (redirectLocation !== "/") {
-			// 	if (redirectLocation?.pathename) {
-			// 		// const splitPathName = redirectLocation.pathname.split("/");
-			// const subDomain =
-			// 	splitPathName[1] in domains
-			// 		? splitPathName[1]
-			// 		: "buddySystem";
-			// setPreviousDomain(subDomain);
-			// console.log(
-			// 	"SET Previous DOMAIN to login PAGE ",
-			// 	subDomain
-			// );
-			// }
-			// console.log("redirectLocation", redirectLocation);
-			// console.log("location", location.state);
-			// previous domain = undefined if no prev exist   /  /
-			// }
-			if (location.state?.pathename) {
-				setPreviousDomain(location.state.pathename);
-				console.log("prev domain", location.state.pathename);
+			if (location.pathname) {
+				const splitPathName = location.pathname.split("/");
+				console.log("split URL ", splitPathName);
+				const subDomain =
+					splitPathName[1] in domains
+						? splitPathName[1]
+						: "buddySystem";
+				setPreviousDomain(subDomain);
+
+				console.log("prev domain", subDomain);
 			} else {
 				setPreviousDomain(undefined);
 			}
@@ -64,7 +54,7 @@ export const LoginPage = () => {
 		auth ? (
 			<Navigate
 				to={redirectLocation}
-				state={{ previousUrl: previousDomain }}
+				state={{ previousDomain: previousDomain }}
 			/>
 		) : (
 			<div className="auth-page">

--- a/front-end/src/pages/welcomePage/WelcomePage.tsx
+++ b/front-end/src/pages/welcomePage/WelcomePage.tsx
@@ -6,7 +6,11 @@ export const WelcomePage = () => {
 	const { auth } = useContext(AuthContext);
 
 	if (!auth) {
-		return <h1>Welcome to the WORKOUT APP</h1>;
+		return (
+			<div className="buddy-system-homepage">
+				<h1>Welcome to the Buddy System</h1>;
+			</div>
+		);
 	} else {
 		return <Navigate to={"workouts"} replace />;
 	}

--- a/front-end/src/pages/welcomePage/WelcomePage.tsx
+++ b/front-end/src/pages/welcomePage/WelcomePage.tsx
@@ -1,10 +1,10 @@
 import { useContext } from "react";
 import { AuthContext } from "../../contexts/AuthProvider";
-import { Navigate } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 
 export const WelcomePage = () => {
 	const { auth } = useContext(AuthContext);
-
+	const location = useLocation();
 	if (!auth) {
 		return (
 			<div className="buddy-system-homepage">

--- a/front-end/src/pages/workoutsPage/WorkoutsPage.tsx
+++ b/front-end/src/pages/workoutsPage/WorkoutsPage.tsx
@@ -17,12 +17,13 @@ export const WorkoutsPage: React.FC<{}> = () => {
 		getAllUsersWorkoutsRequest,
 	] = useRequest(getAllUsersWorkoutsAPI);
 	const [messageApi, contextHolder] = message.useMessage();
-
+	const location = useLocation();
 	useEffect(() => {
 		// once logged in, make API call //session wil always be true here, if sstatement to bypass error
 		if (session) {
 			getAllUsersWorkoutsRequest(session);
 		}
+		console.log("location workouts", location);
 	}, []);
 
 	useEffect(() => {

--- a/front-end/src/styles/App.css
+++ b/front-end/src/styles/App.css
@@ -31,6 +31,14 @@ div.andt-select-selector {
 		background-color: rgb(0, 110, 255);
 	}
 }
+@keyframes fadeInAmiibo {
+	0% {
+		background-color: rgb(69, 150, 86);
+	}
+	100% {
+		background-color: rgb(148, 22, 22);
+	}
+}
 
 @keyframes fadeout {
 	0% {
@@ -62,12 +70,18 @@ div.andt-select-selector {
 	background-color: rgb(0, 110, 255);
 	animation: fadeIn 1s linear;
 }
+
 .workout-buddy-header .logout-button {
 	background-color: #1677ff;
 }
 
 .amiibo-buddy-header {
 	background-color: rgb(148, 22, 22);
+}
+
+.amiibo-buddy-header.from-login {
+	background-color: rgb(148, 22, 22);
+	animation: fadeInAmiibo 1s linear;
 }
 .amiibo-buddy-header .logout-button {
 	background-color: #bc4b4b;

--- a/front-end/src/styles/App.css
+++ b/front-end/src/styles/App.css
@@ -23,17 +23,44 @@ div.andt-select-selector {
 	width: 10px;
 } */
 
+@keyframes fadeIn {
+	0% {
+		background-color: rgb(69, 150, 86);
+	}
+	100% {
+		background-color: rgb(0, 110, 255);
+	}
+}
+
+@keyframes fadeout {
+	0% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 0;
+	}
+}
 /* DOMAINS*/
+.buddy-system-homepage h1 {
+	text-align: center;
+	margin: 30px auto;
+}
 
 .buddy-system-header {
-	background-color: rgb(113, 143, 183);
+	background-color: rgb(69, 150, 86);
+	animation: fadeOut 1s linear;
 }
 .buddy-system-header .logout-button {
-	background-color: #8599b5;
+	background-color: rgb(69, 150, 86);
+}
+
+.buddy-system-header .login-button {
+	background-color: rgb(56, 122, 70);
 }
 
 .workout-buddy-header {
 	background-color: rgb(0, 110, 255);
+	animation: fadeIn 1s linear;
 }
 .workout-buddy-header .logout-button {
 	background-color: #1677ff;

--- a/front-end/src/styles/App.css
+++ b/front-end/src/styles/App.css
@@ -99,6 +99,7 @@ h2 {
 .header {
 	padding: 10px 75px;
 	width: 100%;
+	height: 58px;
 }
 
 .header .content {

--- a/front-end/src/styles/App.css
+++ b/front-end/src/styles/App.css
@@ -48,7 +48,27 @@ div.andt-select-selector {
 		opacity: 0;
 	}
 }
-/* DOMAINS*/
+
+@keyframes fadeWorkoutToBuddySystem {
+	0% {
+		background-color: rgb(0, 110, 255);
+	}
+	100% {
+		background-color: rgb(69, 150, 86);
+	}
+}
+
+@keyframes fadeAmiiboBuddyToBuddySystem {
+	0% {
+		background-color: rgb(148, 22, 22);
+	}
+	100% {
+		background-color: rgb(69, 150, 86);
+	}
+}
+
+\/* DOMAINS*/
+/* 
 .buddy-system-homepage h1 {
 	text-align: center;
 	margin: 30px auto;
@@ -82,12 +102,49 @@ div.andt-select-selector {
 .amiibo-buddy-header.from-login {
 	background-color: rgb(148, 22, 22);
 	animation: fadeInAmiibo 1s linear;
-}
-.amiibo-buddy-header .logout-button {
+}*/
+
+.amiiboBuddy-header .logout-button {
 	background-color: #bc4b4b;
 }
-.amiibo-buddy-header .logout-button button:hover {
+.amiiboBuddy-header .logout-button button:hover {
 	background-color: #734b4b;
+}
+
+/* Fade Headers */
+.workouts-to-buddySystem-header {
+	background-color: rgb(69, 150, 86);
+	animation: fadeWorkoutToBuddySystem 1s linear;
+}
+
+.amiiboBuddy-to-buddySystem-header {
+	background-color: rgb(69, 150, 86);
+	animation: fadeAmiiboBuddyToBuddySystem 1s linear;
+}
+.workouts-header {
+	background-color: rgb(0, 110, 255);
+}
+
+.buddySystem-header {
+	background-color: rgb(69, 150, 86);
+}
+
+.amiiboBuddy-header {
+	background-color: rgb(148, 22, 22);
+}
+
+/* no fade, just login = GREEN */
+
+.fade-undefined-to-buddySystem {
+	background-color: rgb(69, 150, 86);
+}
+
+.fade-amiiboBuddy-to-buddySystem {
+	background-color: rgb(69, 80, 150);
+}
+
+.fade-buddySystem-to-amiiboBuddy {
+	background-color: rgb(69, 80, 150);
 }
 .logo {
 	height: 6em;

--- a/front-end/src/styles/App.css
+++ b/front-end/src/styles/App.css
@@ -67,7 +67,25 @@ div.andt-select-selector {
 	}
 }
 
-\/* DOMAINS*/
+@keyframes fadeBuddySystemToWorkouts {
+	0% {
+		background-color: rgb(69, 150, 86);
+	}
+	100% {
+		background-color: rgb(0, 110, 255);
+	}
+}
+
+@keyframes fadeBuddySystemToAmiiboBuddy {
+	0% {
+		background-color: rgb(69, 150, 86);
+	}
+	100% {
+		background-color: rgb(148, 22, 22);
+	}
+}
+
+/* \DOMAINS */
 /* 
 .buddy-system-homepage h1 {
 	text-align: center;
@@ -121,6 +139,18 @@ div.andt-select-selector {
 	background-color: rgb(69, 150, 86);
 	animation: fadeAmiiboBuddyToBuddySystem 1s linear;
 }
+
+.buddySystem-to-workouts-header {
+	background-color: rgb(0, 110, 255);
+	animation: fadeBuddySystemToWorkouts 1s linear;
+}
+
+.buddySystem-to-amiiboBuddy-header {
+	background-color: rgb(148, 22, 22);
+
+	animation: fadeBuddySystemToAmiiboBuddy 1s linear;
+}
+
 .workouts-header {
 	background-color: rgb(0, 110, 255);
 }


### PR DESCRIPTION
- Deployed new App = buddy-system.vercel.app
    - add domain to allowed domains for GoogleMapsAPI
    - 
- [ ] Add Header to:
    - [ ] when transitioning, animate color change
        - [ ] maybe special class and location state to fade between 
    - [ ] 
    - [x]  logged out homepage
    - [x] login page = Buddy System (green)
    - [x] make header adjust to Subdomain
    - [x] onLoad = empty background loads first, waiting for auth to load
    - [x] update useEffect, so that it initially gets the Domain and sets a domain object, then the use effect rerenders whenever context IsLoading, auth,domainObj OR username updates, and waits for username, then renders all together by setting loading to false
        - [x] - if not authorized, will take you to login page, 
    - [x] get location when entering url, to redirect after Auth.
    - [x] exit workoutbuddy = stays heading
    - [ ] add initalUrl and from Login state to navigate
    - [ ] HEader = will have no State if originally going to a url 
Hitting Log out will refresh location = change domain pathnaim to login, BUT will give STATE of initial URL of amiibo. in header 
