### PR TITLE
reset ant-btn-primary css to change with heading

### DIFF
--- a/front-end/src/apps/pokeBuddy/src/styles/style.css
+++ b/front-end/src/apps/pokeBuddy/src/styles/style.css
@@ -69,7 +69,6 @@
 }
 .recipe-page .ant-radio-button-wrapper-checked::before,
 .recipe-page .pot-size-adjuster,
-.ant-btn-primary,
 .recipe-level-adjuster {
 	background-color: var(--domain-nav-links-active) !important;
 }


### PR DESCRIPTION
- logout/in button was not fading with domain change, 
- removed from pokebuddy styles which was overiding  it