### PR TITLE
Fix LorcanaBuddy routing and backend Node 26 compatibility

### DIFF
--- a/backend-express-app/api/index.js
+++ b/backend-express-app/api/index.js
@@ -5,7 +5,6 @@ const path = require("path");
 const env = require("dotenv");
 const cors = require("cors");
 const { v4 } = require("uuid");
-const jwt = require("jsonwebtoken");
 const bodyParser = require("body-parser");
 
 env.config();

--- a/backend-express-app/package-lock.json
+++ b/backend-express-app/package-lock.json
@@ -16,9 +16,11 @@
 				"cors": "^2.8.5",
 				"dotenv": "^16.1.3",
 				"express": "^4.18.2",
-				"jsonwebtoken": "^9.0.0",
 				"uuid": "^9.0.0",
 				"vercel": "^30.2.1"
+			},
+			"devDependencies": {
+				"nodemon": "^3.1.14"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -3769,11 +3771,6 @@
 				"ieee754": "^1.1.13"
 			}
 		},
-		"node_modules/buffer-equal-constant-time": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
-		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -4533,14 +4530,6 @@
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dependencies": {
 				"safe-buffer": "~5.1.0"
-			}
-		},
-		"node_modules/ecdsa-sig-formatter": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-			"dependencies": {
-				"safe-buffer": "^5.0.1"
 			}
 		},
 		"node_modules/edge-runtime": {
@@ -6102,6 +6091,13 @@
 				"node": ">= 4"
 			}
 		},
+		"node_modules/ignore-by-default": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+			"integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/import-meta-resolve": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-2.2.2.tgz",
@@ -6467,70 +6463,6 @@
 			},
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/jsonwebtoken": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-			"integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-			"dependencies": {
-				"jws": "^3.2.2",
-				"lodash": "^4.17.21",
-				"ms": "^2.1.1",
-				"semver": "^7.3.8"
-			},
-			"engines": {
-				"node": ">=12",
-				"npm": ">=6"
-			}
-		},
-		"node_modules/jsonwebtoken/node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/jsonwebtoken/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-		},
-		"node_modules/jsonwebtoken/node_modules/semver": {
-			"version": "7.5.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-			"integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/jwa": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-			"integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-			"dependencies": {
-				"buffer-equal-constant-time": "1.0.1",
-				"ecdsa-sig-formatter": "1.0.11",
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"node_modules/jws": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-			"integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-			"dependencies": {
-				"jwa": "^1.4.1",
-				"safe-buffer": "^5.0.1"
 			}
 		},
 		"node_modules/keyv": {
@@ -7799,6 +7731,135 @@
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
 			"integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ=="
 		},
+		"node_modules/nodemon": {
+			"version": "3.1.14",
+			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.14.tgz",
+			"integrity": "sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chokidar": "^3.5.2",
+				"debug": "^4",
+				"ignore-by-default": "^1.0.1",
+				"minimatch": "^10.2.1",
+				"pstree.remy": "^1.1.8",
+				"semver": "^7.5.3",
+				"simple-update-notifier": "^2.0.0",
+				"supports-color": "^5.5.0",
+				"touch": "^3.1.0",
+				"undefsafe": "^2.0.5"
+			},
+			"bin": {
+				"nodemon": "bin/nodemon.js"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/nodemon"
+			}
+		},
+		"node_modules/nodemon/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/nodemon/node_modules/brace-expansion": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/nodemon/node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/nodemon/node_modules/has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/nodemon/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/nodemon/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/nodemon/node_modules/semver": {
+			"version": "7.8.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+			"integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/nodemon/node_modules/supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/nopt": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
@@ -8494,6 +8555,13 @@
 			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
 			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
 		},
+		"node_modules/pstree.remy": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+			"integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/pump": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
@@ -9055,6 +9123,32 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
 		},
+		"node_modules/simple-update-notifier": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+			"integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/simple-update-notifier/node_modules/semver": {
+			"version": "7.8.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+			"integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -9477,6 +9571,16 @@
 			"resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
 			"integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
 		},
+		"node_modules/touch": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+			"integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"nodetouch": "bin/nodetouch.js"
+			}
+		},
 		"node_modules/tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -9633,6 +9737,13 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.2.tgz",
 			"integrity": "sha512-TrY6DsjTQQgyS3E3dBaOXf0TpPD8u9FVrVYmKVegJuFw51n/YB9XPt+U6ydzFG5ZIN7+DIjPbNmXoBj9esYhgQ=="
+		},
+		"node_modules/undefsafe": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+			"integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/unicode-canonical-property-names-ecmascript": {
 			"version": "2.0.0",

--- a/backend-express-app/package.json
+++ b/backend-express-app/package.json
@@ -19,8 +19,10 @@
 		"cors": "^2.8.5",
 		"dotenv": "^16.1.3",
 		"express": "^4.18.2",
-		"jsonwebtoken": "^9.0.0",
 		"uuid": "^9.0.0",
 		"vercel": "^30.2.1"
+	},
+	"devDependencies": {
+		"nodemon": "^3.1.14"
 	}
 }

--- a/front-end/src/apps/lorcanaBuddy/src/App.tsx
+++ b/front-end/src/apps/lorcanaBuddy/src/App.tsx
@@ -11,18 +11,18 @@ import { NewInventory } from "./pages/newInventory/NewInventory";
 import { NewInput } from "./pages/newInput/NewInput";
 
 export const LorcanaBuddy = [
-	<Route path="?filter" element={<NewInventory />} key={"LB1"} />,
-	<Route path="myCollection" element={<MyCollection />} key={"LB2"} />,
-	<Route path="browse" element={<Inventory />} key={"LB3"} />,
-	<Route path="wishlist" element={<Wishlist />} key={"LB4"} />,
-	<Route path="addItems" element={<NewInput />} key={"LB4"} />,
-	<Route path="inventory" element={<NewInventory />} key={"LB6"} />,
-	<Route path="tradeOrAdd" element={<TradeOrAddPage />} key={"LB6"} />,
-	<Route path="checklist" element={<Checklist />} key={"LB6"} />,
-	<Route path="newInventory" element={<NewInventory />} key={"LB6"} />,
-	// <Route path="newInput" element={<NewInput />} key={"LB6"} />,
+  <Route index element={<NewInventory />} key={"LB1"} />,
+  <Route path="myCollection" element={<MyCollection />} key={"LB2"} />,
+  <Route path="browse" element={<Inventory />} key={"LB3"} />,
+  <Route path="wishlist" element={<Wishlist />} key={"LB4"} />,
+  <Route path="addItems" element={<NewInput />} key={"LB4"} />,
+  <Route path="inventory" element={<NewInventory />} key={"LB6"} />,
+  <Route path="tradeOrAdd" element={<TradeOrAddPage />} key={"LB6"} />,
+  <Route path="checklist" element={<Checklist />} key={"LB6"} />,
+  <Route path="newInventory" element={<NewInventory />} key={"LB6"} />,
+  // <Route path="newInput" element={<NewInput />} key={"LB6"} />,
 
-	<Route path="*" element={<Navigate to="" />} key={"LB5"} />,
+  <Route path="*" element={<Navigate to="" />} key={"LB5"} />,
 ];
 
 // export const WorkoutBuddy = [

--- a/front-end/src/components/navigation/Navbar.tsx
+++ b/front-end/src/components/navigation/Navbar.tsx
@@ -33,7 +33,7 @@ export const Navbar = () => {
 									to={
 										domain.name === "Buddy System"
 											? `/${page.path}`
-											: `/${domain.path}/${page.path} `
+											: `/${domain.path}/${page.path}`
 									}
 									key={page.name}
 									className={({ isActive, isPending }) =>


### PR DESCRIPTION
- Fix LorcanaBuddy index route (was path="?filter", invalid in RR v6) so /lorcanaBuddy renders correctly
- Remove trailing space from Navbar path template literal causing all subroute nav links to 404 and flicker back
- Remove unused jsonwebtoken import and package (its buffer-equal-constant-time dep uses SlowBuffer, removed in Node 22+)
- Add nodemon as devDependency for backend